### PR TITLE
CIを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rye
+        uses: eifinger/setup-rye@v4
+        with:
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: rye sync
+
+      - name: Ruff check
+        run: rye run ruff check --output-format=github .
+
+  format:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rye
+        uses: eifinger/setup-rye@v4
+        with:
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: rye sync
+
+      - name: Ruff format check
+        run: rye run ruff format --check
+
+  typecheck:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rye
+        uses: eifinger/setup-rye@v4
+        with:
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: rye sync
+
+      - name: Mypy
+        run: rye run mypy src/ --strict


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-processor/issues/9

# この PR で対応する範囲 / この PR で対応しない範囲

以下を実行するCIを追加する。

テストの実行は、テスト自体が未実装のため対応しない。

# 変更点概要

CIを行うGitHub Actionのワークフローを追加。
CIで以下のチェックを行う。

- Linter,Formatter
- 型チェックツール

Lint、Format、型チェックは別のStepとし、アクションが実行されたタイミングですべてチェックされるようにしている。

Ryeのセットアップには、[eifinger/setup-rye](https://github.com/marketplace/actions/python-setup-rye)を利用した。
Rye自体のリポジトリでも[こちら](https://github.com/astral-sh/rye/blob/main/.github/workflows/python-lint.yml#L16)で利用されているので採用した。

# 動作確認内容
CIでエラーとなるように動作確認用のコミットをし、CIが実行されること、すべてのチェックでエラーとなることを確認済み。
https://github.com/nekochans/lgtm-cat-processor/actions/runs/10651239620
