### PR TITLE
LGTM画像作成時のフォーマットをWebPに変更

### DIFF
--- a/src/presentation/handle_process.py
+++ b/src/presentation/handle_process.py
@@ -7,7 +7,6 @@ from infrastructure.s3_repository import (
     create_s3_client,
     create_s3_repository,
 )
-from usecase.convert_to_webp_usecase import ConvertToWebpUsecase
 from usecase.generate_lgtmI_image_usecase import GenerateLgtmImageUsecase
 from usecase.judge_image_usecase import JudgeImageUsecase
 from usecase.store_to_db_usecase import StoreToDbUsecase
@@ -16,7 +15,6 @@ from usecase.store_to_db_usecase import StoreToDbUsecase
 class ProcessType(Enum):
     JUDGE_IMAGE = "judgeImage"
     GENERATE_LGTM_IMAGE = "generateLgtmImage"
-    CONVERT_TO_WEBP = "convertToWebp"
     STORE_TO_DB = "storeToDb"
 
 
@@ -33,7 +31,6 @@ def handle_process(
     generate_lgtm_image_usecase = GenerateLgtmImageUsecase(
         s3_repository, bucket_name, object_key, logger
     )
-    convert_to_webp_usecase = ConvertToWebpUsecase(bucket_name, object_key)
     store_to_db_usecase = StoreToDbUsecase(bucket_name, object_key)
 
     if process not in [e.value for e in ProcessType]:
@@ -44,7 +41,5 @@ def handle_process(
         judge_image_usecase.execute()
     elif process == ProcessType.GENERATE_LGTM_IMAGE.value:
         generate_lgtm_image_usecase.execute()
-    elif process == ProcessType.CONVERT_TO_WEBP.value:
-        convert_to_webp_usecase.execute()
     elif process == ProcessType.STORE_TO_DB.value:
         store_to_db_usecase.execute()

--- a/src/usecase/convert_to_webp_usecase.py
+++ b/src/usecase/convert_to_webp_usecase.py
@@ -1,9 +1,0 @@
-class ConvertToWebpUsecase:
-    def __init__(self, bucket_name: str, object_key: str) -> None:
-        self.bucket_name = bucket_name
-        self.object_key = object_key
-
-    def execute(self) -> None:
-        print("画像をwebpに変換する")
-        print(f"bucket_name: {self.bucket_name}")
-        print(f"object_key: {self.object_key}")

--- a/src/usecase/generate_lgtmI_image_usecase.py
+++ b/src/usecase/generate_lgtmI_image_usecase.py
@@ -8,7 +8,7 @@ from log.logging import AppLogger
 def build_upload_object_key(object_key: str) -> str:
     directory, filename = os.path.split(object_key)
     imagename_without_ext = os.path.splitext(filename)[0]
-    return os.path.join(directory, imagename_without_ext + ".png")
+    return os.path.join(directory, imagename_without_ext + ".webp")
 
 
 class GenerateLgtmImageUsecase:
@@ -73,7 +73,7 @@ class GenerateLgtmImageUsecase:
             draw.text((x_meow, y_meow), meow_text, font=font_meow, fill=(255, 255, 255))
 
             buffer = io.BytesIO()
-            img.save(buffer, format="PNG")
+            img.save(buffer, format="WEBP")
             buffer.seek(0)
             return buffer
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-processor/issues/12

# この PR で対応する範囲 / この PR で対応しない範囲

- LGTM画像がWebP形式で出力されるように変更する


# 変更点概要
LGTM画像作成時のフォーマットをWebPに変更。

当初はPNG形式で出力されたLGTM画像をWebPに変換するためのUseCaseを作成することを想定していたが、画像加工に利用している`Pillow`ではWebP形式での画像の作成が可能であった。
そのためLGTM画像作成時のフォーマットをWebP形式にし、WebP変換を行うことを想定していたUseCaseを削除した。

# レビュアーに重点的にチェックして欲しい点
LGTM画像作成時のフォーマットがPNGからWEbPに変更となる点が現行と異なるが特に懸念点はないと考えている。
もし何かあればコメントもらえると🙏

# 補足情報
StepFunctionsのステートマシンの修正も必要となるため、Terraformのリポジトリに課題を作成して対応する。
