### PR TITLE
LGTM画像の情報をDBに保存

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
     "boto3>=1.35.10",
     "pillow>=10.4.0",
     "boto3-stubs[s3]>=1.35.12",
-    "pymysql>=1.1.1",
+    "sqlalchemy>=2.0.34",
+    "mysql-connector-python>=9.0.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "boto3>=1.35.10",
     "pillow>=10.4.0",
     "boto3-stubs[s3]>=1.35.12",
+    "pymysql>=1.1.1",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"
@@ -22,6 +23,7 @@ managed = true
 dev-dependencies = [
     "ruff>=0.6.3",
     "mypy>=1.11.2",
+    "types-pymysql>=1.1.0.20240524",
 ]
 virtual = true
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -25,6 +25,7 @@ mypy-boto3-s3==1.35.2
 mypy-extensions==1.0.0
     # via mypy
 pillow==10.4.0
+pymysql==1.1.1
 python-dateutil==2.9.0.post0
     # via botocore
 ruff==0.6.3
@@ -34,6 +35,7 @@ six==1.16.0
     # via python-dateutil
 types-awscrt==0.21.2
     # via botocore-stubs
+types-pymysql==1.1.0.20240524
 types-s3transfer==0.10.2
     # via boto3-stubs
 typing-extensions==4.12.2

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -24,8 +24,8 @@ mypy-boto3-s3==1.35.2
     # via boto3-stubs
 mypy-extensions==1.0.0
     # via mypy
+mysql-connector-python==9.0.0
 pillow==10.4.0
-pymysql==1.1.1
 python-dateutil==2.9.0.post0
     # via botocore
 ruff==0.6.3
@@ -33,6 +33,7 @@ s3transfer==0.10.2
     # via boto3
 six==1.16.0
     # via python-dateutil
+sqlalchemy==2.0.34
 types-awscrt==0.21.2
     # via botocore-stubs
 types-pymysql==1.1.0.20240524
@@ -40,5 +41,6 @@ types-s3transfer==0.10.2
     # via boto3-stubs
 typing-extensions==4.12.2
     # via mypy
+    # via sqlalchemy
 urllib3==2.2.2
     # via botocore

--- a/requirements.lock
+++ b/requirements.lock
@@ -22,6 +22,7 @@ jmespath==1.0.1
 mypy-boto3-s3==1.35.2
     # via boto3-stubs
 pillow==10.4.0
+pymysql==1.1.1
 python-dateutil==2.9.0.post0
     # via botocore
 s3transfer==0.10.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -21,17 +21,20 @@ jmespath==1.0.1
     # via botocore
 mypy-boto3-s3==1.35.2
     # via boto3-stubs
+mysql-connector-python==9.0.0
 pillow==10.4.0
-pymysql==1.1.1
 python-dateutil==2.9.0.post0
     # via botocore
 s3transfer==0.10.2
     # via boto3
 six==1.16.0
     # via python-dateutil
+sqlalchemy==2.0.34
 types-awscrt==0.21.2
     # via botocore-stubs
 types-s3transfer==0.10.2
     # via boto3-stubs
+typing-extensions==4.12.2
+    # via sqlalchemy
 urllib3==2.2.2
     # via botocore

--- a/src/domain/lgtm_image_repository_interface.py
+++ b/src/domain/lgtm_image_repository_interface.py
@@ -1,0 +1,9 @@
+from typing import Protocol
+
+
+class LgtmImageRepositoryIntercase(Protocol):
+    def save_lgtm_cat(
+        self,
+        bucket_name: str,
+        object_key: str,
+    ) -> None: ...

--- a/src/domain/lgtm_image_repository_interface.py
+++ b/src/domain/lgtm_image_repository_interface.py
@@ -1,7 +1,7 @@
 from typing import Protocol
 
 
-class LgtmImageRepositoryIntercase(Protocol):
+class LgtmImageRepositoryInterface(Protocol):
     def save_lgtm_cat(
         self,
         bucket_name: str,

--- a/src/infrastructure/db.py
+++ b/src/infrastructure/db.py
@@ -1,0 +1,28 @@
+import os
+from pymysql.connections import Connection
+import pymysql
+
+
+def get_env_var(var_name: str) -> str:
+    value = os.getenv(var_name)
+    if value is None:
+        raise ValueError(f"環境変数 {var_name} が設定されていません")
+    return value
+
+
+def create_db_connection() -> Connection:
+    host = get_env_var("DB_HOSTNAME")
+    user = get_env_var("DB_USERNAME")
+    password = get_env_var("DB_PASSWORD")
+    database = get_env_var("DB_NAME")
+
+    connection = pymysql.connect(
+        host=host,
+        user=user,
+        password=password,
+        database=database,
+        ssl={
+            "ca": "/etc/ssl/certs/ca-certificates.crt",
+        },
+    )
+    return connection

--- a/src/infrastructure/db.py
+++ b/src/infrastructure/db.py
@@ -1,6 +1,6 @@
 import os
-from pymysql.connections import Connection
-import pymysql
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
 
 
 def get_env_var(var_name: str) -> str:
@@ -10,19 +10,13 @@ def get_env_var(var_name: str) -> str:
     return value
 
 
-def create_db_connection() -> Connection:  # type: ignore[type-arg]
+def create_db() -> sessionmaker[Session]:
     host = get_env_var("DB_HOSTNAME")
     user = get_env_var("DB_USERNAME")
     password = get_env_var("DB_PASSWORD")
     database = get_env_var("DB_NAME")
 
-    connection = pymysql.connect(
-        host=host,
-        user=user,
-        password=password,
-        database=database,
-        ssl={
-            "ca": "/etc/ssl/certs/ca-certificates.crt",
-        },
-    )
-    return connection
+    connection_string = f"mysql+mysqlconnector://{user}:{password}@{host}/{database}"
+    engine = create_engine(connection_string)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return SessionLocal

--- a/src/infrastructure/db.py
+++ b/src/infrastructure/db.py
@@ -10,7 +10,7 @@ def get_env_var(var_name: str) -> str:
     return value
 
 
-def create_db_connection() -> Connection:
+def create_db_connection() -> Connection:  # type: ignore[type-arg]
     host = get_env_var("DB_HOSTNAME")
     user = get_env_var("DB_USERNAME")
     password = get_env_var("DB_PASSWORD")

--- a/src/infrastructure/lgtm_image.py
+++ b/src/infrastructure/lgtm_image.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, Integer, String, DateTime, func
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class LgtmImage(Base):
+    __tablename__ = "lgtm_images"
+
+    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+    filename = Column(String(255), unique=True, nullable=False)
+    path = Column(String(255), index=True, nullable=False)
+    created_at = Column(
+        DateTime, nullable=False, server_default=func.current_timestamp()
+    )
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )

--- a/src/infrastructure/lgtm_image_repository.py
+++ b/src/infrastructure/lgtm_image_repository.py
@@ -6,13 +6,18 @@ from log.logging import AppLogger
 
 
 def create_lgtm_image_repository(
-    connection: Connection, logger: AppLogger
+    connection: Connection,  # type: ignore[type-arg]
+    logger: AppLogger,
 ) -> LgtmImageRepositoryIntercase:
     return LtgmImageRepository(connection, logger)
 
 
 class LtgmImageRepository(LgtmImageRepositoryIntercase):
-    def __init__(self, connection: Connection, logger: AppLogger) -> None:
+    def __init__(
+        self,
+        connection: Connection,  # type: ignore[type-arg]
+        logger: AppLogger,
+    ) -> None:
         self.connection = connection
         self.logger = logger
 

--- a/src/infrastructure/lgtm_image_repository.py
+++ b/src/infrastructure/lgtm_image_repository.py
@@ -30,4 +30,5 @@ class LgtmImageRepository(LgtmImageRepositoryInterface):
 
         except SQLAlchemyError as e:
             self.logger.error(f"レコードのインサート中にエラーが発生しました: {e}")
+            session.rollback()
             raise

--- a/src/infrastructure/lgtm_image_repository.py
+++ b/src/infrastructure/lgtm_image_repository.py
@@ -1,4 +1,4 @@
-from domain.lgtm_image_repository_interface import LgtmImageRepositoryIntercase
+from domain.lgtm_image_repository_interface import LgtmImageRepositoryInterface
 from infrastructure.lgtm_image import LgtmImage
 from log.logging import AppLogger
 from sqlalchemy.orm import sessionmaker, Session
@@ -8,11 +8,11 @@ from sqlalchemy.exc import SQLAlchemyError
 def create_lgtm_image_repository(
     session_factory: sessionmaker[Session],
     logger: AppLogger,
-) -> LgtmImageRepositoryIntercase:
-    return LtgmImageRepository(session_factory, logger)
+) -> LgtmImageRepositoryInterface:
+    return LgtmImageRepository(session_factory, logger)
 
 
-class LtgmImageRepository(LgtmImageRepositoryIntercase):
+class LgtmImageRepository(LgtmImageRepositoryInterface):
     def __init__(
         self, session_factory: sessionmaker[Session], logger: AppLogger
     ) -> None:

--- a/src/infrastructure/lgtm_image_repository.py
+++ b/src/infrastructure/lgtm_image_repository.py
@@ -1,0 +1,37 @@
+from typing import List, Tuple
+import pymysql
+from pymysql.connections import Connection
+from domain.lgtm_image_repository_interface import LgtmImageRepositoryIntercase
+from log.logging import AppLogger
+
+
+def create_lgtm_image_repository(
+    connection: Connection, logger: AppLogger
+) -> LgtmImageRepositoryIntercase:
+    return LtgmImageRepository(connection, logger)
+
+
+class LtgmImageRepository(LgtmImageRepositoryIntercase):
+    def __init__(self, connection: Connection, logger: AppLogger) -> None:
+        self.connection = connection
+        self.logger = logger
+
+    def save_lgtm_cat(
+        self,
+        file_name: str,
+        path: str,
+    ) -> None:
+        self.logger.info("レコードのインサートを開始")
+        try:
+            with self.connection.cursor() as cursor:
+                sql = "INSERT INTO lgtm_images(filename, `path`) VALUES (%s, %s)"
+                values: List[Tuple[str, str]] = [(file_name, path)]
+                cursor.executemany(sql, values)
+
+            self.connection.commit()
+            self.logger.info(f"{len(values)} 件のレコードのインサートが成功")
+
+        except pymysql.Error as e:
+            self.logger.error(f"レコードのインサート中にエラーが発生しました: {e}")
+            self.connection.rollback()
+            raise

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,8 @@ def lambda_handler(event: Event, context: Context) -> Response:
 
     request_id = context.aws_request_id  # type: ignore
 
-    handle_process(request_id, process, bucket_name, object_key)
+    upload_bucket_name, upload_object_key = handle_process(
+        request_id, process, bucket_name, object_key
+    )
 
-    return format_response(bucket_name, object_key)
+    return format_response(upload_bucket_name, upload_object_key)

--- a/src/presentation/handle_process.py
+++ b/src/presentation/handle_process.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from domain.lgtm_image_repository_interface import LgtmImageRepositoryIntercase
+from domain.lgtm_image_repository_interface import LgtmImageRepositoryInterface
 from domain.object_storage_repository_interface import ObjectStorageRepositoryInterface
 from infrastructure.db import create_db
 from infrastructure.lgtm_image_repository import create_lgtm_image_repository
@@ -50,7 +50,7 @@ def handle_process(
             logger.error(f"DBへの接続エラー: {e}", exc_info=True)
             raise
 
-        lgtm_image_repository: LgtmImageRepositoryIntercase = (
+        lgtm_image_repository: LgtmImageRepositoryInterface = (
             create_lgtm_image_repository(sessionLocal, logger)
         )
 

--- a/src/presentation/handle_process.py
+++ b/src/presentation/handle_process.py
@@ -20,7 +20,7 @@ class ProcessType(Enum):
 
 def handle_process(
     request_id: str, process: str, bucket_name: str, object_key: str
-) -> None:
+) -> tuple[str, str]:
     logger: AppLogger = setup_logger(request_id, process, bucket_name, object_key)
     s3_client = create_s3_client()
     s3_repository: ObjectStorageRepositoryInterface = create_s3_repository(
@@ -39,7 +39,12 @@ def handle_process(
 
     if process == ProcessType.JUDGE_IMAGE.value:
         judge_image_usecase.execute()
+        return bucket_name, object_key
     elif process == ProcessType.GENERATE_LGTM_IMAGE.value:
-        generate_lgtm_image_usecase.execute()
+        return generate_lgtm_image_usecase.execute()
     elif process == ProcessType.STORE_TO_DB.value:
         store_to_db_usecase.execute()
+        return bucket_name, object_key
+    else:
+        logger.error(f"ProcessTypeで定義されたprocessに必要な処理が実行されていません: {process}")
+        raise RuntimeError(f"ProcessTypeで定義されたprocessに必要な処理が実行されていません: {process}")

--- a/src/presentation/handle_process.py
+++ b/src/presentation/handle_process.py
@@ -1,5 +1,4 @@
 from enum import Enum
-import sys
 
 from domain.object_storage_repository_interface import ObjectStorageRepositoryInterface
 from log.logging import AppLogger, setup_logger
@@ -34,8 +33,8 @@ def handle_process(
     store_to_db_usecase = StoreToDbUsecase(bucket_name, object_key)
 
     if process not in [e.value for e in ProcessType]:
-        print("想定外のprocessが指定された場合は終了する")
-        sys.exit(1)
+        logger.error(f"ProcessTypeで定義されていないprocessが指定されました: {process}")
+        raise ValueError(f"想定外のprocessが指定されました: {process}")
 
     if process == ProcessType.JUDGE_IMAGE.value:
         judge_image_usecase.execute()
@@ -46,5 +45,9 @@ def handle_process(
         store_to_db_usecase.execute()
         return bucket_name, object_key
     else:
-        logger.error(f"ProcessTypeで定義されたprocessに必要な処理が実行されていません: {process}")
-        raise RuntimeError(f"ProcessTypeで定義されたprocessに必要な処理が実行されていません: {process}")
+        logger.error(
+            f"ProcessTypeで定義されたprocessに必要な処理が実行されていません: {process}"
+        )
+        raise RuntimeError(
+            f"ProcessTypeで定義されたprocessに必要な処理が実行されていません: {process}"
+        )

--- a/src/usecase/generate_lgtmI_image_usecase.py
+++ b/src/usecase/generate_lgtmI_image_usecase.py
@@ -77,7 +77,7 @@ class GenerateLgtmImageUsecase:
             buffer.seek(0)
             return buffer
 
-    def execute(self) -> None:
+    def execute(self) -> tuple[str, str]:
         self.logger.info("LGTM画像の作成を開始")
         try:
             cat_image = self.s3repository.fetch_image(self.bucket_name, self.object_key)
@@ -97,6 +97,8 @@ class GenerateLgtmImageUsecase:
             )
 
             self.logger.info("LGTM画像の作成に成功")
+
+            return upload_bucket_name, upload_object_key
 
         except ValueError as e:
             self.logger.error(e, exc_info=True)

--- a/src/usecase/store_to_db_usecase.py
+++ b/src/usecase/store_to_db_usecase.py
@@ -1,9 +1,35 @@
+import os
+from domain.lgtm_image_repository_interface import LgtmImageRepositoryIntercase
+from log.logging import AppLogger
+
+
+def extract_filename_without_ext(object_key: str) -> str:
+    base = os.path.basename(object_key)
+    ext = os.path.splitext(base)[1]
+    return base[: len(base) - len(ext)]
+
+
 class StoreToDbUsecase:
-    def __init__(self, bucket_name: str, object_key: str) -> None:
+    def __init__(
+        self,
+        lgtm_image_repository: LgtmImageRepositoryIntercase,
+        bucket_name: str,
+        object_key: str,
+        logger: AppLogger,
+    ) -> None:
         self.bucket_name = bucket_name
         self.object_key = object_key
+        self.logger = logger
+        self.lgtm_image_repository = lgtm_image_repository
 
     def execute(self) -> None:
-        print("画像情報を永続化する")
-        print(f"bucket_name: {self.bucket_name}")
-        print(f"object_key: {self.object_key}")
+        self.logger.info("LGTM画像情報のDBへの保存を開始")
+        try:
+            path = os.path.dirname(self.object_key)
+            filenameWithoutExt = extract_filename_without_ext(self.object_key)
+
+            self.lgtm_image_repository.save_lgtm_cat(filenameWithoutExt, path)
+            self.logger.info("LGTM画像情報のDBへの保存が成功")
+        except Exception as e:
+            self.logger.error(e, exc_info=True)
+            raise

--- a/src/usecase/store_to_db_usecase.py
+++ b/src/usecase/store_to_db_usecase.py
@@ -1,5 +1,5 @@
 import os
-from domain.lgtm_image_repository_interface import LgtmImageRepositoryIntercase
+from domain.lgtm_image_repository_interface import LgtmImageRepositoryInterface
 from log.logging import AppLogger
 
 
@@ -12,7 +12,7 @@ def extract_filename_without_ext(object_key: str) -> str:
 class StoreToDbUsecase:
     def __init__(
         self,
-        lgtm_image_repository: LgtmImageRepositoryIntercase,
+        lgtm_image_repository: LgtmImageRepositoryInterface,
         bucket_name: str,
         object_key: str,
         logger: AppLogger,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/16

# この PR で対応する範囲 / この PR で対応しない範囲

- LGTM画像の情報をDBに保存するUseCaseを実装
- テストはこのPRの対象外とする

# 変更点概要
LGTM画像の情報をDBに保存するUseCaseを実装。
MySQLのDBへの接続のため、~~ライブラリに[PyMySQL](https://github.com/PyMySQL/PyMySQL)を利用した。~~

こちらの[コメント](https://github.com/nekochans/lgtm-cat-processor/pull/19#discussion_r1760050903)で提案があった[SQLAlchemy](https://docs.sqlalchemy.org/en/20/#)を採用した。

また、以下の点も合わせて対応を行なった。
- [次のタスクにアップロード先のS3バケットとオブジェクトキーを渡すように変更](https://github.com/nekochans/lgtm-cat-processor/commit/be76ad2e03110f3095ca2219fa943873573284c3)
    - こちらは不具合の修正。画像加工後にアップロード先の情報を次のタスクに渡すはずが、アップロード元(画像加工前)の情報を渡していたので修正した。
- [ログ出力とシステム終了処理を他のコードに合わせて修正](https://github.com/nekochans/lgtm-cat-processor/commit/05374bfa8385ee88bf604386b3f37a75c3049404)

# 補足情報
コメント https://github.com/nekochans/lgtm-cat-processor/pull/19#discussion_r1760030493 に記載した通り、Typecheckでエラーとなってしまっているが、原因がわからなかったのでコメントで回避する方針とした。
もし解決策を知っていたらコメントもらえると助かる🙏
