### PR TITLE
CDを設定

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -7,10 +7,11 @@ on:
 
 env:
   ECR_REPOSITORY: prod-lgtm-image-processor
+  FUNCTION_NAME: prod-lgtm-image-processor
 
 jobs:
   build:
-    name: Build and Deploy to Production
+    name: Build Docker Image and Deploy to Lambda to Production
     timeout-minutes: 15
     runs-on: ubuntu-22.04
 
@@ -55,3 +56,15 @@ jobs:
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/arm64
+
+      - name: Deploy to Lambda
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: prod-lgtm-image-processor-deploy
+          hide-cloudwatch-logs: true
+          buildspec-override: buildspec.yml
+          env-vars-for-codebuild: |
+            IMAGE_URI,
+            FUNCTION_NAME
+        env:
+          IMAGE_URI: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -1,0 +1,57 @@
+name: cd-production
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v[0-9].[0-9]+.[0-9]+
+
+env:
+  ECR_REPOSITORY: prod-lgtm-image-processor
+
+jobs:
+  build:
+    name: Build and Deploy to Production
+    timeout-minutes: 15
+    runs-on: ubuntu-22.04
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: "ap-northeast-1"
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
+          tags: type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/arm64

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -7,10 +7,11 @@ on:
 
 env:
   ECR_REPOSITORY: stg-lgtm-image-processor
+  FUNCTION_NAME: stg-lgtm-image-processor
 
 jobs:
   build:
-    name: Build and Deploy to Staging
+    name: Build Docker Image and Deploy to Lambda to Staging
     timeout-minutes: 15
     runs-on: ubuntu-22.04
 
@@ -55,3 +56,15 @@ jobs:
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/arm64
+
+      - name: Deploy to Lambda
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: stg-lgtm-image-processor-deploy
+          hide-cloudwatch-logs: true
+          buildspec-override: buildspec.yml
+          env-vars-for-codebuild: |
+            IMAGE_URI,
+            FUNCTION_NAME
+        env:
+          IMAGE_URI: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -1,0 +1,57 @@
+name: cd-staging
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  ECR_REPOSITORY: stg-lgtm-image-processor
+
+jobs:
+  build:
+    name: Build and Deploy to Staging
+    timeout-minutes: 15
+    runs-on: ubuntu-22.04
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: "ap-northeast-1"
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}
+          tags: type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/arm64

--- a/README.md
+++ b/README.md
@@ -1,9 +1,57 @@
 # lgtm-cat-processor
 S3にアップロードされた画像からLGTM画像を作成するLamnda関数
 
+# デプロイ
+
+デプロイ先の環境は、ステージングと本番の2つが存在します。
+
+デプロイには以下の2つの手順が必要になります。
+
+1. DockerイメージをECRにpush
+2. Lambda関数の更新
+
+それぞれの詳細手順は下記の通りです。
+
+## 1. DockerイメージをECRにpush
+
+GitHub Actionsワークフロー内で自動的に実行されます。
+
+実行タイミングは以下の通りです。
+
+- ステージング
+    - mainブランチへのPRのマージ時に実行
+- 本番
+    - セマンティックバージョニングに基づいたリリースタグ（例：v1.0.0）が追加された時に実行
+
+## 2. Lambda関数の更新
+
+以下のコマンドを実行して、Lambda関数を更新してください。
+
+`image_uri`にはECRにpushされたイメージのURIを指定してください。
+
+
+-  ステージング
+```
+# Lambda関数の更新
+aws lambda update-function-code --function-name stg-lgtm-image-processor --image-uri { image_uri }
+
+# Lambda関数の更新が完了するまで待機
+aws lambda wait function-updated --function-name stg-lgtm-image-processor
+```
+
+- 本番
+```
+# Lambda関数の更新
+aws lambda update-function-code --function-name prod-lgtm-image-processor --image-uri { image_uri }
+
+# Lambda関数の更新が完了するまで待機
+aws lambda wait function-updated --function-name prod-lgtm-image-processor
+```
+
 # font
 - Google Fonts を利用
 
 LGTMテキストの追加に利用しています。
 
 https://fonts.google.com/specimen/M+PLUS+Rounded+1c?preview.text_type=custom&sidebar.open=true&selection.family=Truculenta:wght@100#pairings
+

--- a/README.md
+++ b/README.md
@@ -5,15 +5,6 @@ S3にアップロードされた画像からLGTM画像を作成するLamnda関�
 
 デプロイ先の環境は、ステージングと本番の2つが存在します。
 
-デプロイには以下の2つの手順が必要になります。
-
-1. DockerイメージをECRにpush
-2. Lambda関数の更新
-
-それぞれの詳細手順は下記の通りです。
-
-## 1. DockerイメージをECRにpush
-
 GitHub Actionsワークフロー内で自動的に実行されます。
 
 実行タイミングは以下の通りです。
@@ -22,31 +13,6 @@ GitHub Actionsワークフロー内で自動的に実行されます。
     - mainブランチへのPRのマージ時に実行
 - 本番
     - セマンティックバージョニングに基づいたリリースタグ（例：v1.0.0）が追加された時に実行
-
-## 2. Lambda関数の更新
-
-以下のコマンドを実行して、Lambda関数を更新してください。
-
-`image_uri`にはECRにpushされたイメージのURIを指定してください。
-
-
--  ステージング
-```
-# Lambda関数の更新
-aws lambda update-function-code --function-name stg-lgtm-image-processor --image-uri { image_uri }
-
-# Lambda関数の更新が完了するまで待機
-aws lambda wait function-updated --function-name stg-lgtm-image-processor
-```
-
-- 本番
-```
-# Lambda関数の更新
-aws lambda update-function-code --function-name prod-lgtm-image-processor --image-uri { image_uri }
-
-# Lambda関数の更新が完了するまで待機
-aws lambda wait function-updated --function-name prod-lgtm-image-processor
-```
 
 # font
 - Google Fonts を利用

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,7 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+       - aws lambda update-function-code --function-name ${FUNCTION_NAME} --image-uri ${IMAGE_URI}
+       - aws lambda wait function-updated --function-name ${FUNCTION_NAME}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/13

# この PR で対応する範囲 / この PR で対応しない範囲

- GitHub ActionsにCDを設定する
- Lambdaのデプロイはローカル環境から実行することとし、CD上では行わない

# 変更点概要

CDをGitHub Actionsワークフローで構築しました。

デプロイ手順については、以下の内容を確認してください。
[デプロイ手順をREADMEに記載](https://github.com/nekochans/lgtm-cat-processor/pull/20/commits/a9c76566de10cbf46ebfe5d26eb9ba9744c0500d)

Lambdaの更新をGitHub Actionsワークフロー上ではなく、ローカル環境から実行している理由は以下の通りです。
本来は、次のステップをワークフローに追加し、CI/CD上でLambda関数の更新も行う予定でした。

```
      - name: Deploy to Lambda
        env:
          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
          IMAGE_URI: ${{ steps.meta.outputs.tags }}
        run: |
          aws lambda update-function-code --function-name ${{ env.FUNCTION_NAME }} --image-uri ${{ env.IMAGE_URI }}
          aws lambda wait function-updated --function-name ${{ env.FUNCTION_NAME }}
```

しかし、`aws lambda update-function-code`コマンドの実行結果に、Lambdaに設定されている環境変数など公開したくない情報が含まれることが判明しました。そのため、Lambda関数の更新をワークフロー内で行うことを断念し、代わりに手動更新の手順をREADMEに記載することで対応しています。