### PR TITLE
S3にアップロードする際に画像ファイルの拡張子を明示的に指定するように変更

### DIFF
--- a/src/infrastructure/s3_repository.py
+++ b/src/infrastructure/s3_repository.py
@@ -1,6 +1,5 @@
 import io
 import boto3
-import mimetypes
 from mypy_boto3_s3 import S3Client
 from domain.object_storage_repository_interface import ObjectStorageRepositoryInterface
 from log.logging import AppLogger

--- a/src/infrastructure/s3_repository.py
+++ b/src/infrastructure/s3_repository.py
@@ -16,13 +16,6 @@ def create_s3_repository(
     return S3Repository(s3_client, logger)
 
 
-def get_content_type(file_name: str) -> str:
-    content_type, _ = mimetypes.guess_type(file_name)
-    if content_type is None:
-        return "application/octet-stream"
-    return content_type
-
-
 class S3Repository(ObjectStorageRepositoryInterface):
     def __init__(self, s3_client: S3Client, logger: AppLogger) -> None:
         self.s3_client = s3_client
@@ -43,11 +36,9 @@ class S3Repository(ObjectStorageRepositoryInterface):
     ) -> None:
         self.logger.info("画像のアップロードを開始")
 
-        content_type = get_content_type(object_key)
-
         self.s3_client.put_object(
             Bucket=bucket_name,
             Key=object_key,
             Body=processed_image,
-            ContentType=content_type,
+            ContentType="image/webp",
         )

--- a/src/infrastructure/s3_repository.py
+++ b/src/infrastructure/s3_repository.py
@@ -1,5 +1,6 @@
 import io
 import boto3
+import mimetypes
 from mypy_boto3_s3 import S3Client
 from domain.object_storage_repository_interface import ObjectStorageRepositoryInterface
 from log.logging import AppLogger
@@ -13,6 +14,13 @@ def create_s3_repository(
     s3_client: S3Client, logger: AppLogger
 ) -> ObjectStorageRepositoryInterface:
     return S3Repository(s3_client, logger)
+
+
+def get_content_type(file_name: str) -> str:
+    content_type, _ = mimetypes.guess_type(file_name)
+    if content_type is None:
+        return "application/octet-stream"
+    return content_type
 
 
 class S3Repository(ObjectStorageRepositoryInterface):
@@ -35,6 +43,11 @@ class S3Repository(ObjectStorageRepositoryInterface):
     ) -> None:
         self.logger.info("画像のアップロードを開始")
 
+        content_type = get_content_type(object_key)
+
         self.s3_client.put_object(
-            Bucket=bucket_name, Key=object_key, Body=processed_image
+            Bucket=bucket_name,
+            Key=object_key,
+            Body=processed_image,
+            ContentType=content_type,
         )


### PR DESCRIPTION
<!-- (Copilot Review への依頼: レビューコメントは日本語で記載してください -->

# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/22

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/lgtm-cat-processor/issues/22 の問題を解決するための必要最低限の改修を実施。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

2024年9月22日からS3にアップロードされた `.webp` のContent-Typeが `binary/octet-stream` になってしまっている現象を確認。

その為S3にアップロードする際に `ContentType="image/webp"` を明示的に指定するように変更。

# レビュアーに重点的にチェックして欲しい点

@kobayashi-m42 ユーザー影響があるから一旦先にマージする🙏

# 補足情報

画像ファイルは `.webp` 固定なので `infrastructure/s3_repository.py` に直接書いてしまっているが今後別の拡張子に対応する場合は `upload_image` の引数で渡せるように修正する必要がある。