### PR TITLE
背景輝度に基づいたテキスト色の自動選択機能を実装

### DIFF
--- a/src/usecase/generate_lgtmI_image_usecase.py
+++ b/src/usecase/generate_lgtmI_image_usecase.py
@@ -13,7 +13,7 @@ def build_upload_object_key(object_key: str) -> str:
 
 class GenerateLgtmImageUsecase:
     # 輝度の閾値（0-255）。この値より大きい場合は黒文字、小さい場合は白文字
-    BRIGHTNESS_THRESHOLD = 127
+    BRIGHTNESS_THRESHOLD = 160
 
     def __init__(
         self,


### PR DESCRIPTION
# issueURL

#29

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲**
- LGTM画像生成時に、テキスト描画領域の背景輝度を計算する機能
- 背景輝度に基づいてテキスト色（黒 or 白）を自動選択する機能

**対応しない範囲**
- テキストの配置位置の調整
- フォントサイズの動的変更
- その他のテキストスタイル（影、縁取りなど）の追加

# 変更点概要

LGTM画像生成時に、従来は常に白色だったテキストを、背景の明るさに応じて黒または白に自動的に切り替えるようにした。これにより、明るい背景の画像でもテキストの視認性が確保される。

具体的には以下のメソッドを追加した：
- `get_average_brightness`: 指定領域の平均輝度を計算
- `choose_text_color_by_brightness`: 輝度に基づいて適切なテキスト色を選択

輝度の閾値は定数 `BRIGHTNESS_THRESHOLD = 160`として定義した。
- 「より明るい画像」だけを黒文字にする
- 中間〜暗めの背景では白文字が採用されるようになる

# レビュアーに重点的にチェックして欲しい点

実際に作成した画像を確認し、文字色が適切かどうか確認をお願いします。

## 白文字
<img width="403" height="266" alt="スクリーンショット 2025-11-05 8 56 48" src="https://github.com/user-attachments/assets/870d8cfc-8eb8-4028-8c3a-6e8d7a7dd532" />
<img width="267" height="403" alt="スクリーンショット 2025-11-05 8 57 04" src="https://github.com/user-attachments/assets/4907093a-85eb-44b9-8f56-302e0fa67ef2" />
<img width="271" height="403" alt="スクリーンショット 2025-11-05 8 57 22" src="https://github.com/user-attachments/assets/97f72dab-a86f-44b9-ae68-7ab6857b02b6" />
<img width="406" height="326" alt="スクリーンショット 2025-11-05 8 59 29" src="https://github.com/user-attachments/assets/35eadbce-f77a-4790-82e1-180cc9e39ea5" />

## 黒文字
<img width="403" height="267" alt="スクリーンショット 2025-11-05 8 54 48" src="https://github.com/user-attachments/assets/65a5d982-8116-40e9-becd-669d4c549729" />
<img width="268" height="402" alt="スクリーンショット 2025-11-05 8 56 20" src="https://github.com/user-attachments/assets/a8265707-35c3-42e7-89b0-6dce24267d9b" />
<img width="401" height="267" alt="スクリーンショット 2025-11-05 9 01 04" src="https://github.com/user-attachments/assets/7160a83d-1119-4dc2-b6a1-e9dbc642dad4" />

