### PR TITLE
既存LGTM画像を再生成するスクリプトを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ wheels/
 
 # IDEA
 .idea
+
+# logs
+logs/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,230 @@
+# LGTM画像再生成スクリプト
+
+既存のLGTM画像を再生成して、テキスト配置を最適化するスクリプトです。
+
+## 概要
+
+S3バケット内の全画像に対してLambda関数を実行し、「LGTMeow」のテキストが猫の顔に重ならないように最適化されたLGTM画像を再生成します。
+
+## 前提条件
+
+1. AWS CLIの設定が完了していること
+2. 適切なAWSプロファイルが設定されていること
+3. boto3がインストールされていること
+
+```bash
+# boto3のインストール（プロジェクトルートで実行）
+uv sync
+```
+
+## 使用方法
+
+### 基本的な使い方
+
+```bash
+# ステージング環境で全画像を再生成
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor
+
+# 本番環境で全画像を再生成
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket prod-lgtmeow-cat-images \
+  --lambda-function prod-lgtm-image-processor
+
+# AWSプロファイルを指定する場合
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor \
+  --profile lgtm-cat
+```
+
+### テスト実行（期間指定）
+
+```bash
+# 2025年11月7日の画像のみを再生成
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor \
+  --start-date 2025/11/07 \
+  --end-date 2025/11/07
+
+# 2025年11月の画像のみを再生成（プレフィックス指定）
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor \
+  --prefix 2025/11/
+```
+
+### ドライラン実行
+
+実際のLambda実行を行わず、対象画像の確認のみを行います。
+
+```bash
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor \
+  --dry-run
+```
+
+## オプション一覧
+
+| オプション | 必須 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `--bucket` | ✓ | - | S3バケット名 |
+| `--lambda-function` | ✓ | - | Lambda関数名 |
+| `--profile` | | - | AWSプロファイル名（指定しない場合はデフォルトプロファイルを使用） |
+| `--start-date` | | - | 開始日（YYYY/MM/DD形式） |
+| `--end-date` | | - | 終了日（YYYY/MM/DD形式） |
+| `--prefix` | | "" | オブジェクトキーのプレフィックス |
+| `--dry-run` | | False | ドライラン実行 |
+| `--log-dir` | | logs | ログファイルを保存するディレクトリ |
+
+## 実行例
+
+### ステップ1: ドライランで対象確認
+
+```bash
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor \
+  --start-date 2025/11/07 \
+  --end-date 2025/11/07 \
+  --dry-run
+```
+
+### ステップ2: 小規模テスト実行
+
+```bash
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor \
+  --start-date 2025/11/07 \
+  --end-date 2025/11/07
+```
+
+### ステップ3: 本番実行
+
+```bash
+# まずステージング環境で全画像を再生成
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor
+
+# 問題なければ本番環境で実行
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket prod-lgtmeow-cat-images \
+  --lambda-function prod-lgtm-image-processor
+```
+
+## ログファイル
+
+スクリプト実行時、ログは以下の両方に出力されます：
+
+1. **コンソール**: 実行中の進捗をリアルタイムで確認
+2. **ログファイル**: 実行履歴を保存（デフォルト: `logs/regenerate_YYYYMMDD_HHMMSS.log`）
+
+### ログファイル名の形式
+
+```
+logs/regenerate_20251107_120000.log
+```
+
+タイムスタンプ付きで保存されるため、複数回実行しても履歴が残ります。
+
+### ログディレクトリの変更
+
+```bash
+# カスタムディレクトリを指定
+uv run python scripts/regenerate_lgtm_images.py \
+  --bucket stg-lgtmeow-cat-images \
+  --lambda-function stg-lgtm-image-processor \
+  --log-dir /path/to/custom/logs
+```
+
+## 出力例
+
+### コンソール出力（ログファイルにも同じ内容が保存される）
+
+```
+2025-11-07 12:00:00 - INFO - ============================================================
+2025-11-07 12:00:00 - INFO - LGTM画像再生成スクリプト開始
+2025-11-07 12:00:00 - INFO - ============================================================
+2025-11-07 12:00:00 - INFO - ログファイル: logs/regenerate_20251107_120000.log
+2025-11-07 12:00:00 - INFO - バケット: stg-lgtmeow-cat-images
+2025-11-07 12:00:00 - INFO - Lambda関数: stg-lgtm-image-processor
+2025-11-07 12:00:00 - INFO - ============================================================
+2025-11-07 12:00:00 - INFO - バケット 'stg-lgtmeow-cat-images' からオブジェクトキーを取得中...
+2025-11-07 12:00:05 - INFO - 取得完了: 150件の画像が見つかりました
+2025-11-07 12:00:05 - INFO - 処理開始: 150件の画像を処理します
+2025-11-07 12:00:10 - INFO - ✓ 成功: 2025/11/07/11/xxx.jpeg
+2025-11-07 12:00:11 - INFO - 進捗: 1/150 (成功: 1, 失敗: 0)
+...
+2025-11-07 12:10:00 - INFO - ============================================================
+2025-11-07 12:10:00 - INFO - 実行結果サマリー
+2025-11-07 12:10:00 - INFO - ============================================================
+2025-11-07 12:10:00 - INFO - 総件数:     150
+2025-11-07 12:10:00 - INFO - 成功:       148
+2025-11-07 12:10:00 - INFO - 失敗:       2
+2025-11-07 12:10:00 - INFO - スキップ:   0
+2025-11-07 12:10:00 - INFO - ============================================================
+```
+
+## エラーハンドリング
+
+- Lambda実行が失敗した場合でも処理は継続されます
+- 失敗した画像はログに詳細情報と共に記録されます
+- 最終的に失敗が1件以上ある場合、終了コード1で終了します
+
+### 成功判定
+
+Lambda関数が正常に実行されたかどうかは、以下の条件で判定されます：
+
+- `StatusCode == 200`: AWS Lambda APIの呼び出しが成功
+- `FunctionError is None`: Lambda関数内でエラーが発生していない
+
+これらの条件を全て満たす場合、成功と判定されます。
+
+**注意**: `StatusCode == 200` だけでは不十分です。Lambda関数内でエラーが発生した場合でも、API呼び出し自体は成功するため `StatusCode` は 200 になりますが、`FunctionError` フィールドが設定されます。
+
+### エラーログの詳細
+
+Lambda実行が失敗した場合、以下の情報がログに出力されます：
+
+```
+2025-11-07 22:57:15 - ERROR - ✗ 失敗: 2025/11/04/11/xxx.jpg - FunctionError: Unhandled
+2025-11-07 22:57:15 - ERROR -   レスポンス: {"errorType":"RuntimeError","errorMessage":"Failed to process image","stackTrace":[...]}
+```
+
+出力される情報：
+- **FunctionError**: Lambda関数実行エラーの種類（Unhandled/Handledなど、エラーがない場合はNone）
+- **レスポンス**: Lambda関数からの完全なレスポンス（JSON形式、1行）
+
+## 注意事項
+
+1. **処理時間**: 画像は1つずつ逐次的に処理されるため、大量の画像がある場合は時間がかかります
+2. **コスト**: 大量の画像を処理する場合、Lambda実行コストが発生します
+3. **S3上書き**: 既存の画像は同じオブジェクトキーで上書きされます
+4. **テスト推奨**: 本番環境で実行する前に、必ずステージング環境でテストしてください
+
+## トラブルシューティング
+
+### AWS認証エラー
+
+```bash
+# デフォルトプロファイルを確認
+aws configure list
+
+# 特定のプロファイルを確認
+aws configure list --profile lgtm-cat
+
+# 必要に応じてプロファイルを設定
+aws configure --profile lgtm-cat
+```
+
+### boto3がインストールされていない
+
+```bash
+# プロジェクトルートで実行
+uv sync
+```

--- a/scripts/regenerate_lgtm_images.py
+++ b/scripts/regenerate_lgtm_images.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+既存のLGTM画像を再生成するスクリプト
+
+S3バケット内の全画像に対してLambda関数を実行し、
+テキスト配置が最適化されたLGTM画像を再生成します。
+"""
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def setup_logging(log_dir: str = "logs") -> str:
+    """
+    ロギング設定を行い、コンソールとファイルの両方に出力
+
+    Args:
+        log_dir: ログファイルを保存するディレクトリ
+
+    Returns:
+        ログファイルのパス
+    """
+    # ログディレクトリ作成
+    log_path = Path(log_dir)
+    log_path.mkdir(exist_ok=True)
+
+    # ログファイル名（タイムスタンプ付き）
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = log_path / f"regenerate_{timestamp}.log"
+
+    # ロガー設定
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+
+    # フォーマッター
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
+    # コンソールハンドラー
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.INFO)
+    console_handler.setFormatter(formatter)
+
+    # ファイルハンドラー
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(formatter)
+
+    # ハンドラーを追加
+    logger.addHandler(console_handler)
+    logger.addHandler(file_handler)
+
+    return str(log_file)
+
+
+logger = logging.getLogger(__name__)
+
+
+class LgtmImageRegenerator:
+    """LGTM画像再生成クラス"""
+
+    def __init__(
+        self,
+        bucket_name: str,
+        lambda_function_name: str,
+        aws_profile: str | None = None,
+    ) -> None:
+        """
+        初期化
+
+        Args:
+            bucket_name: S3バケット名
+            lambda_function_name: Lambda関数名
+            aws_profile: AWSプロファイル名(Noneの場合はデフォルトプロファイルを使用)
+        """
+        self.bucket_name = bucket_name
+        self.lambda_function_name = lambda_function_name
+
+        # AWS クライアント初期化
+        if aws_profile:
+            session = boto3.Session(profile_name=aws_profile)
+        else:
+            session = boto3.Session()
+        self.s3_client = session.client("s3")
+        self.lambda_client = session.client("lambda")
+
+        # 統計情報
+        self.total_count = 0
+        self.success_count = 0
+        self.failure_count = 0
+        self.skipped_count = 0
+        self.skipped_date_count = 0
+
+    def list_all_objects(
+        self,
+        prefix: str = "",
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> list[str]:
+        """
+        S3バケット内の全オブジェクトキーを取得
+
+        Args:
+            prefix: オブジェクトキーのプレフィックス
+            start_date: 開始日(YYYY/MM/DD形式)
+            end_date: 終了日(YYYY/MM/DD形式)
+
+        Returns:
+            オブジェクトキーのリスト
+        """
+        logger.info(f"バケット '{self.bucket_name}' からオブジェクトキーを取得中...")
+
+        object_keys: list[str] = []
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+
+        try:
+            for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
+                if "Contents" not in page:
+                    continue
+
+                for obj in page["Contents"]:
+                    key = obj["Key"]
+
+                    # 画像ファイルのみを対象(.jpeg、.jpg、.png)
+                    if not key.lower().endswith((".jpeg", ".jpg", ".png")):
+                        continue
+
+                    # 期間フィルタリング
+                    if start_date or end_date:
+                        if not self._is_within_date_range(key, start_date, end_date):
+                            self.skipped_date_count += 1
+                            continue
+
+                    object_keys.append(key)
+
+            logger.info(f"取得完了: {len(object_keys)}件の画像が見つかりました")
+            if self.skipped_date_count > 0:
+                logger.info(f"期間外でスキップ: {self.skipped_date_count}件")
+
+            return object_keys
+
+        except ClientError as e:
+            logger.error(f"S3オブジェクト取得エラー: {e}")
+            raise
+
+    def _is_within_date_range(
+        self, object_key: str, start_date: str | None, end_date: str | None
+    ) -> bool:
+        """
+        オブジェクトキーが指定期間内かチェック
+
+        Args:
+            object_key: オブジェクトキー（例: 2025/11/07/11/xxx.jpeg）
+            start_date: 開始日（YYYY/MM/DD形式）
+            end_date: 終了日（YYYY/MM/DD形式）
+
+        Returns:
+            期間内ならTrue
+        """
+        # オブジェクトキーから日付部分を抽出（YYYY/MM/DD）
+        parts = object_key.split("/")
+        if len(parts) < 3:
+            return True  # 日付構造でない場合はスキップしない
+
+        try:
+            obj_date_str = "/".join(parts[:3])  # YYYY/MM/DD
+            obj_date = datetime.strptime(obj_date_str, "%Y/%m/%d")
+
+            if start_date:
+                start = datetime.strptime(start_date, "%Y/%m/%d")
+                if obj_date < start:
+                    return False
+
+            if end_date:
+                end = datetime.strptime(end_date, "%Y/%m/%d")
+                if obj_date > end:
+                    return False
+
+            return True
+
+        except ValueError:
+            # 日付パースエラーの場合はスキップしない
+            return True
+
+    def invoke_lambda(self, object_key: str, dry_run: bool = False) -> dict[str, Any]:
+        """
+        Lambda関数を実行してLGTM画像を再生成
+
+        Args:
+            object_key: S3オブジェクトキー
+            dry_run: ドライラン実行の場合True
+
+        Returns:
+            実行結果
+        """
+        payload = {
+            "process": "generateLgtmImage",
+            "image": {"bucketName": self.bucket_name, "objectKey": object_key},
+        }
+
+        if dry_run:
+            logger.info(f"[DRY RUN] Lambda実行: {object_key}")
+            return {"status": "skipped", "object_key": object_key}
+
+        try:
+            response = self.lambda_client.invoke(
+                FunctionName=self.lambda_function_name,
+                InvocationType="RequestResponse",
+                Payload=json.dumps(payload),
+            )
+
+            status_code = response["StatusCode"]
+            response_payload = json.loads(response["Payload"].read())
+
+            # 成功判定: AWS Lambda APIが成功し、Lambda関数内でエラーが発生していない
+            is_success = status_code == 200 and response.get("FunctionError") is None
+
+            if is_success:
+                logger.info(f"✓ 成功: {object_key}")
+                return {"status": "success", "object_key": object_key}
+            else:
+                # エラーログ出力（シンプル）
+                function_error = response.get("FunctionError", "None")
+                logger.error(f"✗ 失敗: {object_key} - FunctionError: {function_error}")
+                logger.error(
+                    f"  レスポンス: {json.dumps(response_payload, ensure_ascii=False)}"
+                )
+
+                return {
+                    "status": "failure",
+                    "object_key": object_key,
+                    "error": f"FunctionError: {function_error}",
+                }
+
+        except ClientError as e:
+            logger.error(f"✗ Lambda実行エラー: {object_key} - {str(e)}")
+            return {"status": "failure", "object_key": object_key, "error": str(e)}
+        except Exception as e:
+            logger.error(
+                f"✗ 予期しないエラー: {object_key} - {type(e).__name__}: {str(e)}"
+            )
+            return {"status": "failure", "object_key": object_key, "error": str(e)}
+
+    def regenerate_all(
+        self,
+        object_keys: list[str],
+        dry_run: bool = False,
+    ) -> None:
+        """
+        全画像を逐次的に再生成
+
+        Args:
+            object_keys: オブジェクトキーのリスト
+            dry_run: ドライラン実行の場合True
+        """
+        self.total_count = len(object_keys)
+
+        if self.total_count == 0:
+            logger.warning("処理対象の画像がありません")
+            return
+
+        logger.info(f"処理開始: {self.total_count}件の画像を処理します")
+        if dry_run:
+            logger.info("【ドライランモード】実際のLambda実行は行いません")
+
+        for key in object_keys:
+            result = self.invoke_lambda(key, dry_run)
+
+            if result["status"] == "success":
+                self.success_count += 1
+            elif result["status"] == "failure":
+                self.failure_count += 1
+            elif result["status"] == "skipped":
+                self.skipped_count += 1
+
+            # 進捗表示
+            processed = self.success_count + self.failure_count + self.skipped_count
+            logger.info(
+                f"進捗: {processed}/{self.total_count} "
+                f"(成功: {self.success_count}, 失敗: {self.failure_count}, ドライラン: {self.skipped_count})"
+            )
+
+    def print_summary(self) -> None:
+        """実行結果のサマリーを出力"""
+        logger.info("=" * 60)
+        logger.info("実行結果サマリー")
+        logger.info("=" * 60)
+        logger.info(f"総件数:     {self.total_count}")
+        logger.info(f"成功:       {self.success_count}")
+        logger.info(f"失敗:       {self.failure_count}")
+        logger.info(f"ドライラン: {self.skipped_count}")
+        logger.info(f"期間外:     {self.skipped_date_count}")
+        logger.info("=" * 60)
+
+
+def main() -> None:
+    """メイン処理"""
+    parser = argparse.ArgumentParser(description="既存のLGTM画像を再生成するスクリプト")
+
+    parser.add_argument(
+        "--bucket",
+        type=str,
+        required=True,
+        help="S3バケット名（例: stg-lgtmeow-cat-images）",
+    )
+
+    parser.add_argument(
+        "--lambda-function",
+        type=str,
+        required=True,
+        help="Lambda関数名（例: stg-lgtm-image-processor）",
+    )
+
+    parser.add_argument(
+        "--profile",
+        type=str,
+        help="AWSプロファイル名（指定しない場合はデフォルトプロファイルを使用）",
+    )
+
+    parser.add_argument(
+        "--start-date",
+        type=str,
+        help="開始日（YYYY/MM/DD形式、例: 2025/11/01）",
+    )
+
+    parser.add_argument(
+        "--end-date",
+        type=str,
+        help="終了日（YYYY/MM/DD形式、例: 2025/11/07）",
+    )
+
+    parser.add_argument(
+        "--prefix",
+        type=str,
+        default="",
+        help="オブジェクトキーのプレフィックス（例: 2025/11/）",
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="ドライラン実行（実際のLambda実行は行わない）",
+    )
+
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        default="logs",
+        help="ログファイルを保存するディレクトリ（デフォルト: logs）",
+    )
+
+    args = parser.parse_args()
+
+    # ロギング設定
+    log_file = setup_logging(args.log_dir)
+    logger.info("=" * 60)
+    logger.info("LGTM画像再生成スクリプト開始")
+    logger.info("=" * 60)
+    logger.info(f"ログファイル: {log_file}")
+    logger.info(f"バケット: {args.bucket}")
+    logger.info(f"Lambda関数: {args.lambda_function}")
+    if args.profile:
+        logger.info(f"AWSプロファイル: {args.profile}")
+    logger.info("=" * 60)
+
+    try:
+        regenerator = LgtmImageRegenerator(
+            bucket_name=args.bucket,
+            lambda_function_name=args.lambda_function,
+            aws_profile=args.profile,
+        )
+
+        # オブジェクトキー取得
+        object_keys = regenerator.list_all_objects(
+            prefix=args.prefix,
+            start_date=args.start_date,
+            end_date=args.end_date,
+        )
+
+        # 再生成実行
+        regenerator.regenerate_all(object_keys, dry_run=args.dry_run)
+
+        # サマリー出力
+        regenerator.print_summary()
+
+        # 失敗がある場合は終了コード1
+        if regenerator.failure_count > 0:
+            sys.exit(1)
+
+    except Exception as e:
+        logger.error(f"エラーが発生しました: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/35

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲**

- 既存のLGTM画像を再生成するスクリプト（`scripts/regenerate_lgtm_images.py`）を追加
- スクリプトの使用方法を説明するREADME（`scripts/README.md`）を追加
- ログディレクトリを.gitignoreに追加
- stg環境での画像再生成を実施済み

**対応しない範囲**

- なし

# 変更点概要

Amazon Rekognitionの顔検出機能を活用してテキスト配置を最適化する機能が実装されたため、既存のLGTM画像を再生成して最適化を適用するスクリプトを追加した。

S3バケット内の全画像に対してLambda関数を呼び出し、テキストが猫の顔に重ならないように最適化されたLGTM画像を再生成する。

**主な機能**

- S3バケットから画像を取得してLambda関数を実行
- 期間指定での部分的な再生成（`--start-date`、`--end-date`）
- ドライラン実行（`--dry-run`）で対象確認
- コンソールとファイルへのログ出力
- 処理結果のサマリー表示

**実装方針について**

画像は1つずつ逐次的に処理されるため実行時間がかかるが、並行処理にするとスクリプトが複雑になる。また、スクリプトの実行は1回のみを想定しているため、シンプルな逐次処理の実装としている。

# 補足情報

stg環境で全画像の再生成を実施済みである。テキスト配置の最適化が正しく適用されているか、stg環境の画像を確認してほしい。

このPRで問題がなければ、本番環境でも同様に画像再生成を実施する予定である。