### PR TITLE
GitHub Actionsにpytestによる自動テスト実行ジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,21 @@ jobs:
 
       - name: Mypy
         run: uv run mypy src/ --strict
+
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Test
+        run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,9 @@ make format            # コードフォーマット
 
 # 型チェック
 make typecheck         # mypy --strictで実行
+
+# テスト
+make test              # pytestで実行
 ```
 
 ## デプロイ
@@ -81,12 +84,11 @@ make typecheck         # mypy --strictで実行
 
 ## テストとCI
 
-CIワークフロー（`.github/workflows/ci.yml`）は3つのジョブを実行：
+CIワークフロー（`.github/workflows/ci.yml`）は4つのジョブを実行：
 1. `uv run ruff check` - リント
 2. `uv run ruff format --check` - フォーマット検証
-3. `uv run mypy src/ --strict` - 型チェック
-
-**現在、ユニットテストはコードベースに存在しません。**
+3. `uv run mypy src/ tests/ --strict` - 型チェック
+4. `uv run pytest -vv -s src/ tests/` - ユニットテスト
 
 ## 依存関係
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint fix format typecheck
+.PHONY: lint fix format typecheck test
 
 lint:
 	uv run ruff check
@@ -11,3 +11,6 @@ format:
 
 typecheck:
 	uv run mypy src/ tests/ --strict
+
+test:
+	uv run pytest -vv -s src/ tests/


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/34

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- GitHub Actions CI に pytest によるテストジョブを追加
- Makefile にテスト実行コマンドを追加
- CLAUDE.md（開発者向けドキュメント）にテスト実行方法とCI構成を反映

## 対応しない範囲
- テストコードの追加・修正は本PRの範囲外

# 変更点概要

CIパイプラインでユニットテストが実行されていなかったため、コード品質を保証する仕組みが不十分だった。

`.github/workflows/ci.yml` に `test` ジョブを追加し、`make test` コマンドで pytest を実行できるようにした。また、開発者向けドキュメント（CLAUDE.md）にテスト実行方法とCIの4つのジョブ構成を明記し、テストの実行をプロジェクトの標準フローに組み込んだ。