### PR TITLE
LGTM画像生成Usecaseのテストを追加

### DIFF
--- a/tests/usecase/test_generate_lgtm_image_usecase.py
+++ b/tests/usecase/test_generate_lgtm_image_usecase.py
@@ -1,5 +1,6 @@
 # 絶対厳守：編集前に必ずAI実装ルールを読む
 
+import io
 import os
 from unittest.mock import Mock, patch
 
@@ -96,7 +97,7 @@ class TestGenerateLgtmImageUsecase:
         """正常にLGTM画像が生成・アップロードできること"""
         # Arrange
         test_image_bytes = b"test original image"
-        test_generated_image = b"test lgtm image"
+        test_generated_image = io.BytesIO(b"test lgtm image")
 
         mock_s3_repository.fetch_image.return_value = test_image_bytes
 
@@ -210,7 +211,7 @@ class TestGenerateLgtmImageUsecase:
         """S3アップロード失敗時に例外が伝播すること"""
         # Arrange
         test_image_bytes = b"test original image"
-        test_generated_image = b"test lgtm image"
+        test_generated_image = io.BytesIO(b"test lgtm image")
 
         mock_s3_repository.fetch_image.return_value = test_image_bytes
         mock_s3_repository.upload_image.side_effect = Exception("S3 upload error")
@@ -239,7 +240,7 @@ class TestGenerateLgtmImageUsecase:
         """環境変数GENERATE_LGTM_IMAGE_UPLOAD_BUCKETが未設定の場合に例外が発生すること"""
         # Arrange
         test_image_bytes = b"test original image"
-        test_generated_image = b"test lgtm image"
+        test_generated_image = io.BytesIO(b"test lgtm image")
 
         mock_s3_repository.fetch_image.return_value = test_image_bytes
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/46

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- LGTM画像生成機能（Usecase層）のユニットテスト追加

## 対応しない範囲
- 他のユースケース（StoreToDbUsecase、JudgeImageUsecase）のテスト
- リクエストルーティング（handle_process）のテスト

上記は別PRで対応予定である。

# 変更点概要

Issue #46「既存コードにユニットテストを追加する」の一環として、システムの中核機能であるLGTM画像生成Usecaseのテストを実装した。

## 追加したテスト

### Usecase層
- `test_generate_lgtm_image_usecase.py`
  - `build_upload_object_key()` 関数
    - 様々な拡張子（jpg/png/jpeg）からwebpへの変換
    - ディレクトリパス付きファイル名の処理
    - 拡張子なしファイル名の処理
  - `GenerateLgtmImageUsecase.execute()` メソッド
    - 正常系: S3取得→猫検出→画像生成→S3アップロードの統合フロー
    - 異常系: S3取得エラー、画像生成エラー、S3アップロードエラー
    - 設定検証: 環境変数未設定時のエラー検出