### PR TITLE
SQLAlchemy 2.0の型安全性とトランザクション管理のベストプラクティスに準拠

### DIFF
--- a/src/infrastructure/db.py
+++ b/src/infrastructure/db.py
@@ -1,3 +1,4 @@
+# 絶対厳守：編集前に必ずAI実装ルールを読む
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
@@ -18,5 +19,5 @@ def create_db() -> sessionmaker[Session]:
 
     connection_string = f"mysql+mysqlconnector://{user}:{password}@{host}/{database}"
     engine = create_engine(connection_string)
-    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    SessionLocal = sessionmaker(autoflush=False, bind=engine)
     return SessionLocal

--- a/src/infrastructure/lgtm_image.py
+++ b/src/infrastructure/lgtm_image.py
@@ -1,5 +1,8 @@
-from sqlalchemy import Column, Integer, String, DateTime, func
-from sqlalchemy.orm import DeclarativeBase
+# 絶対厳守：編集前に必ずAI実装ルールを読む
+from datetime import datetime
+
+from sqlalchemy import Integer, String, DateTime, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
 class Base(DeclarativeBase):
@@ -9,13 +12,15 @@ class Base(DeclarativeBase):
 class LgtmImage(Base):
     __tablename__ = "lgtm_images"
 
-    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
-    filename = Column(String(255), unique=True, nullable=False)
-    path = Column(String(255), index=True, nullable=False)
-    created_at = Column(
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True, nullable=False
+    )
+    filename: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    path: Mapped[str] = mapped_column(String(255), index=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.current_timestamp()
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
         server_default=func.current_timestamp(),

--- a/src/infrastructure/lgtm_image_repository.py
+++ b/src/infrastructure/lgtm_image_repository.py
@@ -1,5 +1,4 @@
-from typing import cast
-
+# 絶対厳守：編集前に必ずAI実装ルールを読む
 from domain.lgtm_image_repository_interface import LgtmImageRepositoryInterface
 from infrastructure.lgtm_image import LgtmImage
 from log.logging import AppLogger
@@ -24,21 +23,18 @@ class LgtmImageRepository(LgtmImageRepositoryInterface):
     def save_lgtm_cat(self, file_name: str, path: str) -> int:
         self.logger.info("レコードのインサートを開始")
         try:
-            with self.session_factory() as session:
+            with self.session_factory.begin() as session:
                 lgtm_image = LgtmImage(filename=file_name, path=path)
                 session.add(lgtm_image)
-                session.commit()
-                session.refresh(lgtm_image)  # IDを取得するためにリフレッシュ
+                session.flush()
 
                 # IDがNoneでないことを確認（autoincrement=Trueのため通常は必ず値が設定される）
                 if lgtm_image.id is None:
                     raise RuntimeError("画像IDの取得に失敗しました")
 
-                image_id = cast(int, lgtm_image.id)
-                self.logger.info(f"レコードのインサートが成功 (ID: {image_id})")
-                return image_id
+                self.logger.info(f"レコードのインサートが成功 (ID: {lgtm_image.id})")
+                return lgtm_image.id
 
         except SQLAlchemyError as e:
             self.logger.error(f"レコードのインサート中にエラーが発生しました: {e}")
-            session.rollback()
             raise

--- a/tests/infrastructure/test_lgtm_image_repository.py
+++ b/tests/infrastructure/test_lgtm_image_repository.py
@@ -23,8 +23,9 @@ class TestLgtmImageRepository:
     def mock_session_factory(self, mock_session: Mock) -> Mock:
         """sessionmakerのモック"""
         mock_factory = Mock(spec=sessionmaker)
-        mock_factory.return_value.__enter__ = Mock(return_value=mock_session)
-        mock_factory.return_value.__exit__ = Mock(return_value=None)
+        # session_factory.begin()がコンテキストマネージャーとして動作するようにする
+        mock_factory.begin.return_value.__enter__ = Mock(return_value=mock_session)
+        mock_factory.begin.return_value.__exit__ = Mock(return_value=None)
         return mock_factory
 
     @pytest.fixture
@@ -55,22 +56,13 @@ class TestLgtmImageRepository:
         test_path = "test/path"
         test_id = 123
 
-        # LgtmImageモックの作成
-        mock_lgtm_image = Mock(spec=LgtmImage)
-        mock_lgtm_image.id = test_id
-
-        # session.addが呼ばれた時にモックを保存
-        def mock_add(obj: object) -> None:
-            if isinstance(obj, LgtmImage):
-                # refreshで呼ばれた時に返すためにオブジェクトを保存
-                mock_session._added_object = mock_lgtm_image
-
-        mock_session.add.side_effect = mock_add
-        mock_session.refresh.side_effect = (
+        # モックの設定
+        mock_session.add.side_effect = (
             lambda obj: setattr(obj, "id", test_id)
             if isinstance(obj, LgtmImage)
             else None
         )
+        mock_session.flush.return_value = None
 
         # Act
         result = repository.save_lgtm_cat(test_filename, test_path)
@@ -78,31 +70,29 @@ class TestLgtmImageRepository:
         # Assert
         assert result == test_id
         mock_session.add.assert_called_once()
-        mock_session.commit.assert_called_once()
-        mock_session.refresh.assert_called_once()
+        mock_session.flush.assert_called_once()
 
     def test_save_lgtm_cat_sqlalchemy_error(
         self,
         repository: LgtmImageRepository,
         mock_session: Mock,
     ) -> None:
-        """SQLAlchemyエラー時にrollbackして例外が伝播すること"""
+        """SQLAlchemyエラー時に例外が伝播すること"""
         # Arrange
         test_filename = "test_image"
         test_path = "test/path"
         error_message = "Database connection error"
 
         mock_session.add.return_value = None
-        mock_session.commit.side_effect = SQLAlchemyError(error_message)
+        mock_session.flush.side_effect = SQLAlchemyError(error_message)
 
         # Act & Assert
         with pytest.raises(SQLAlchemyError, match=error_message):
             repository.save_lgtm_cat(test_filename, test_path)
 
-        # rollbackが呼ばれることを確認
+        # 適切なメソッドが呼ばれたことを確認
         mock_session.add.assert_called_once()
-        mock_session.commit.assert_called_once()
-        mock_session.rollback.assert_called_once()
+        mock_session.flush.assert_called_once()
 
     def test_save_lgtm_cat_id_is_none(
         self,
@@ -114,20 +104,17 @@ class TestLgtmImageRepository:
         test_filename = "test_image"
         test_path = "test/path"
 
-        # refreshしてもidがNoneのままのケース
-        def mock_refresh(obj: object) -> None:
-            if isinstance(obj, LgtmImage):
-                obj.id = None  # type: ignore[assignment]
-
-        mock_session.refresh.side_effect = mock_refresh
+        # flushしてもidがNoneのままのケース
+        mock_session.add.return_value = None
+        mock_session.flush.return_value = None
+        # IDが設定されないケースをシミュレート（addのside_effectでIDを設定しない）
 
         # Act & Assert
         with pytest.raises(RuntimeError, match="画像IDの取得に失敗しました"):
             repository.save_lgtm_cat(test_filename, test_path)
 
         mock_session.add.assert_called_once()
-        mock_session.commit.assert_called_once()
-        mock_session.refresh.assert_called_once()
+        mock_session.flush.assert_called_once()
 
     @pytest.mark.parametrize(
         "test_filename,test_path,test_id",
@@ -153,11 +140,12 @@ class TestLgtmImageRepository:
         """様々なパス形式で正常に保存できること"""
 
         # Arrange
-        def mock_refresh(obj: object) -> None:
-            if isinstance(obj, LgtmImage):
-                obj.id = test_id  # type: ignore[assignment]
-
-        mock_session.refresh.side_effect = mock_refresh
+        mock_session.add.side_effect = (
+            lambda obj: setattr(obj, "id", test_id)
+            if isinstance(obj, LgtmImage)
+            else None
+        )
+        mock_session.flush.return_value = None
 
         # Act
         result = repository.save_lgtm_cat(test_filename, test_path)
@@ -165,5 +153,4 @@ class TestLgtmImageRepository:
         # Assert
         assert result == test_id
         mock_session.add.assert_called_once()
-        mock_session.commit.assert_called_once()
-        mock_session.refresh.assert_called_once()
+        mock_session.flush.assert_called_once()


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/52

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲:**
- SQLAlchemy 2.0の型安全性対応（`Mapped` 型の導入）
- トランザクション管理のベストプラクティスへの準拠（`begin()` コンテキストマネージャーの使用）
- 型チェック警告（`type: ignore[assignment]`）の解消
- 変更に伴うテストコードの修正

**対応しない範囲:**
- その他のビジネスロジックの変更
- 新機能の追加

# 変更点概要

1. **SQLAlchemy 2.0の型安全性対応**
   - `lgtm_image.py` で `Column` 定義を `Mapped` + `mapped_column` に移行
   - 各カラムに適切な型ヒント（`Mapped[int]`, `Mapped[str]`, `Mapped[datetime]`）を追加

2. **トランザクション管理のベストプラクティス準拠**
   - `db.py` で `autocommit=False` を削除（SQLAlchemy 2.0デフォルト動作に準拠）
   - `lgtm_image_repository.py` で以下を変更:
     - `session_factory()` → `session_factory.begin()` コンテキストマネージャーを使用
     - `session.commit()` + `session.refresh()` → `session.flush()` に変更
     - 明示的な `session.rollback()` を削除（コンテキストマネージャーが自動処理）

3. **型チェック警告の解消**
   - `lgtm_image_repository.py` で `type: ignore[assignment]` を削除
   - `Mapped` 型導入により型推論が正しく機能し、警告が解消

4. **テストコードの修正**
   - `test_lgtm_image_repository.py` でモック設定を `begin()` コンテキストマネージャーに対応
   - `commit()` / `refresh()` / `rollback()` の検証を `flush()` の検証に変更