### PR TITLE
CD の Docker ビルドキャッシュを有効化し、ビルド時間を短縮する

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -33,11 +33,6 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,6 +51,8 @@ jobs:
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy to Lambda
         uses: aws-actions/aws-codebuild-run-build@v1

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -33,11 +33,6 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,6 +51,8 @@ jobs:
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Deploy to Lambda
         uses: aws-actions/aws-codebuild-run-build@v1


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/54

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- ステージング環境・本番環境のCDワークフローにGitHub Actions Cacheを利用したDockerビルドキャッシュを導入する

## 対応しない範囲
- 実際のビルド時間改善効果の測定（マージ後のワークフロー実行で確認する）

# 変更点概要

GitHub ActionsのDockerビルドにおいて、毎回フルビルドが発生していた問題を改善するため、`docker/build-push-action`に`cache-from`と`cache-to`の設定を追加した。

これにより、2回目以降のビルドでレイヤーキャッシュが再利用され、デプロイ時間の大幅な短縮が期待できる。
また、Docker Buildxが既にマルチプラットフォームビルドをサポートしているため、不要な`Set up QEMU`ステップを削除。

# 補足
ビルド時間は以下のように改善された
- ビルド無し: 2m 36s
- ビルド有り: 5s
