### PR TITLE
AWS BedrockとS3 Vectorsのデフォルトリージョンをap-northeast-1に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,9 @@ CIワークフロー（`.github/workflows/ci.yml`）は4つのジョブを実行
 - `GENERATE_LGTM_IMAGE_UPLOAD_BUCKET` - 処理済み画像のアップロード先S3バケット
 - `VECTOR_INDEX_BUCKET` - ベクトルインデックス保存用のS3 Vectorsバケット名
 - `VECTOR_INDEX_NAME` - S3 Vectorsのインデックス名
-- `BEDROCK_REGION` - AWS Bedrockのリージョン（デフォルト: us-east-1）
+- `BEDROCK_REGION` - AWS Bedrockのリージョン（デフォルト: ap-northeast-1）
 - `BEDROCK_MODEL_ID` - Bedrockで使用する画像埋め込みモデルID（デフォルト: cohere.embed-v4:0）
-- `S3_VECTORS_REGION` - AWS S3 Vectorsのリージョン（デフォルト: us-east-1）
+- `S3_VECTORS_REGION` - AWS S3 Vectorsのリージョン（デフォルト: ap-northeast-1）
 
 ## GitとGitHubワークフロールール
 

--- a/src/infrastructure/bedrock_repository.py
+++ b/src/infrastructure/bedrock_repository.py
@@ -14,7 +14,7 @@ from log.logging import AppLogger
 
 
 def create_bedrock_client() -> BedrockRuntimeClient:
-    region_name = os.environ.get("BEDROCK_REGION", "us-east-1")
+    region_name = os.environ.get("BEDROCK_REGION", "ap-northeast-1")
     return boto3.client("bedrock-runtime", region_name=region_name)
 
 

--- a/src/infrastructure/s3_vectors_repository.py
+++ b/src/infrastructure/s3_vectors_repository.py
@@ -16,7 +16,7 @@ from log.logging import AppLogger
 
 
 def create_s3_client_for_vector_storage() -> S3VectorsClient:
-    region_name = os.environ.get("S3_VECTORS_REGION", "us-east-1")
+    region_name = os.environ.get("S3_VECTORS_REGION", "ap-northeast-1")
     return boto3.client("s3vectors", region_name=region_name)
 
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-processor/issues/60

# この PR で対応する範囲 / この PR で対応しない範囲

この PR では以下を対応する：
- `BEDROCK_REGION`のデフォルト値をap-northeast-1に変更
- `S3_VECTORS_REGION`のデフォルト値をap-northeast-1に変更
- CLAUDE.mdのドキュメント更新
- 既存の画像のインデックスをap-northeast-1のS3 Vectorsに登録（`scripts/create_initial_image_index/create_initial_image_index.py`を実行）

# 変更点概要

S3 VectorsがAWS re:Invent 2025でGAとなり東京リージョン（ap-northeast-1）で利用可能になったため、AWS BedrockとS3 Vectorsのデフォルトリージョンをus-east-1からap-northeast-1に変更する。

これにより、S3 Vectors、Bedrock、Lambdaが同じ東京リージョンに統一され、レイテンシを最小化できる。

# 変更ファイル

- `src/infrastructure/bedrock_repository.py`: デフォルトリージョンをap-northeast-1に変更
- `src/infrastructure/s3_vectors_repository.py`: デフォルトリージョンをap-northeast-1に変更  
- `CLAUDE.md`: 環境変数のドキュメントを更新

# 補足情報

リージョン統一により、今まで2秒かかっていたインデックス登録処理が約1秒に短縮された。